### PR TITLE
prevent error message when double "stopping" recording

### DIFF
--- a/R/gg_record.R
+++ b/R/gg_record.R
@@ -70,6 +70,8 @@ gg_record <- function(dir = NULL,
   GG_RECORDING_ENV$scale        <- scale
   GG_RECORDING_ENV$limitsize    <- limitsize
 
+  GG_RECORDING_ENV$shims_registered <- FALSE
+
   register_camcorder_shims()
 
   if( !"package:ggplot2" %in% search()){

--- a/R/shims.R
+++ b/R/shims.R
@@ -16,6 +16,7 @@ declare_shims <- function(){
 }
 
 register_camcorder_shims <- function(){
+
   if(length(ls(print_envs)) == 0){
     declare_shims()
   }
@@ -41,10 +42,16 @@ register_camcorder_shims <- function(){
     )
   }
 
+  GG_RECORDING_ENV$shims_registered <- TRUE
+
 }
 
 detach_camcorder_shims <- function(){
-  detach(".camcorder")
+
+  if(!is.null(GG_RECORDING_ENV$shims_registered) &
+     isTRUE(GG_RECORDING_ENV$shims_registered)){
+    detach(".camcorder")
+  }
 
   if("package:ggplot2" %in% search()){
     registerS3method(
@@ -63,6 +70,9 @@ detach_camcorder_shims <- function(){
       envir = getNamespace("patchwork")
     )
   }
+
+  GG_RECORDING_ENV$shims_registered <- FALSE
+
 }
 
 


### PR DESCRIPTION
if "double stopping" recording (calling gg_playback with stop recording true, or calling gg_stop_recording twice), now no warnings about detaching a non-existant namespace will occur