### PR TITLE
Fix automatic recording with ggplot2 >= 4.0.0 (S7)

### DIFF
--- a/R/recording.R
+++ b/R/recording.R
@@ -12,6 +12,30 @@
 #'
 record_ggplot <- function(x, ...) {
 
+  ## ggsave() draws the plot via grid.draw(), whose ggplot method calls
+  ## print(). With ggplot2 < 4.0.0 that inner print() resolved to ggplot2's
+  ## own print.ggplot inside its namespace, but with S7 (>= 4.0.0) it
+  ## dispatches back into this shim and recurses. Restore ggplot2's print
+  ## method while saving, mirroring what record_patchwork does.
+  if(ggplot2_is_s7() && !is.null(GG_RECORDING_ENV$ggplot2_print)){
+
+    registerS3method(
+      genname = "print",
+      class = "ggplot2::ggplot",
+      method = GG_RECORDING_ENV$ggplot2_print,
+      envir = getNamespace("ggplot2")
+    )
+
+    on.exit({
+      registerS3method(
+        genname = "print",
+        class = "ggplot2::ggplot",
+        method = record_ggplot,
+        envir = getNamespace("camcorder")
+      )
+    })
+  }
+
   plot_file <-
     file.path(GG_RECORDING_ENV$recording_dir, paste0(
       format(Sys.time(), "%Y_%m_%d_%H_%M_%OS6"),

--- a/R/shims.R
+++ b/R/shims.R
@@ -17,12 +17,31 @@ register_camcorder_shims <- function(){
   declare_lib_shims()
 
   if("package:ggplot2" %in% search()){
-    registerS3method(
-      genname = "print",
-      class = "ggplot",
-      method = "record_ggplot",
-      envir = getNamespace("camcorder")
-    )
+
+    if(ggplot2_is_s7()){
+      ## ggplot2 >= 4.0.0 plot objects are S7, with class vector
+      ## c("ggplot2::ggplot", "ggplot", ...). S3 dispatch finds ggplot2's
+      ## method for "ggplot2::ggplot" before any method for "ggplot", so the
+      ## shim must be registered on the qualified class name. Keep a copy of
+      ## ggplot2's own method so it can be restored on detach.
+      if(is.null(GG_RECORDING_ENV$ggplot2_print)){
+        GG_RECORDING_ENV$ggplot2_print <-
+          utils::getS3method("print", "ggplot2::ggplot")
+      }
+      registerS3method(
+        genname = "print",
+        class = "ggplot2::ggplot",
+        method = record_ggplot,
+        envir = getNamespace("camcorder")
+      )
+    }else{
+      registerS3method(
+        genname = "print",
+        class = "ggplot",
+        method = "record_ggplot",
+        envir = getNamespace("camcorder")
+      )
+    }
   }
 
   if("package:patchwork" %in% search()){
@@ -46,12 +65,25 @@ detach_camcorder_shims <- function(){
   }
 
   if("package:ggplot2" %in% search()){
-    registerS3method(
-      genname = "print",
-      class = "ggplot",
-      method = "print.ggplot",
-      envir = getNamespace("ggplot2")
-    )
+    if(ggplot2_is_s7()){
+      ## print.ggplot no longer exists in the ggplot2 namespace in
+      ## ggplot2 >= 4.0.0; restore the method object captured at registration
+      if(!is.null(GG_RECORDING_ENV$ggplot2_print)){
+        registerS3method(
+          genname = "print",
+          class = "ggplot2::ggplot",
+          method = GG_RECORDING_ENV$ggplot2_print,
+          envir = getNamespace("ggplot2")
+        )
+      }
+    }else{
+      registerS3method(
+        genname = "print",
+        class = "ggplot",
+        method = "print.ggplot",
+        envir = getNamespace("ggplot2")
+      )
+    }
   }
 
   if("package:patchwork" %in% search()){
@@ -106,6 +138,12 @@ camcorder_warn_suppress <- function(package, warn.conflicts = FALSE){
 
   return(warn.conflicts)
 
+}
+
+## ggplot2 4.0.0 rewrote its object system from S3 to S7,
+## changing the class that print dispatches on
+ggplot2_is_s7 <- function(){
+  utils::packageVersion("ggplot2") >= "4.0.0"
 }
 
 


### PR DESCRIPTION
> [!NOTE]
> This patch was researched, written, and tested by **Claude (Anthropic's AI, via Claude Code)** at my request. I'm submitting it after reviewing it and verifying it fixes my own workflow. Happy to iterate on it if you'd prefer changes.

Fixes #60.

## What broke

ggplot2 4.0.0 rewrote its object system from S3 to S7. Plot objects now have the class vector:

```
c("ggplot2::ggplot", "ggplot", "ggplot2::gg", "S7_object", "gg")
```

and ggplot2 registers its print method on the **qualified** name `print.ggplot2::ggplot`. S3 dispatch walks the class vector in order, so camcorder's shim — registered on plain `"ggplot"` — is never reached. Automatic recording silently stopped; `record_polaroid()` kept working because it doesn't rely on print dispatch.

There are two follow-on problems that only surface once dispatch is fixed:

1. **Infinite recursion in `record_ggplot()`.** `ggsave()` draws via `grid.draw()`, whose ggplot method just calls `print(x)`. With ggplot2 < 4.0.0 that inner `print()` resolved lexically to `print.ggplot` inside ggplot2's namespace, silently bypassing camcorder's override — an accidental recursion breaker. Under S7 there is no `print.ggplot` binding to shadow dispatch, so the inner call re-enters the shim and recurses until R hits the device limit ("too many open devices").
2. **`gg_stop_recording()` errors.** `detach_camcorder_shims()` restores by looking up `"print.ggplot"` in ggplot2's namespace, which no longer exists in 4.x.

## The fix (all gated on `packageVersion("ggplot2") >= "4.0.0"`; older versions keep the exact original code path)

- `register_camcorder_shims()`: register `record_ggplot` on `"ggplot2::ggplot"` via plain `registerS3method()` (no new dependencies — this is what S7 method registration does under the hood), and capture ggplot2's original print method first.
- `record_ggplot()`: restore ggplot2's print method around the `ggsave()` call, mirroring the pattern `record_patchwork()` already uses, to break the recursion.
- `detach_camcorder_shims()`: restore the captured method object instead of looking up the removed name.

Patchwork needs no changes: `"patchwork"` is still first in its class vector (verified with patchwork 1.3.1), so the existing shim keeps working.

## Testing (macOS, R 4.x, ggplot2 4.0.3, patchwork 1.3.1)

End-to-end: `gg_record()` → `print()` of a ggplot records a PNG; patchwork prints record; `gg_resize_film()` re-records; `gg_stop_recording()` runs cleanly and printing returns to normal (no further files recorded); saved PNGs are non-blank.

`testthat`: `[ FAIL 2 | WARN 0 | SKIP 0 | PASS 15 ]` with `NOT_CRAN=true`. The 2 failures are the ggplot2/patchwork **snapshot PNG comparisons**: the new files are visually identical to the stored snapshots (byte-level rendering differences under ggplot2 4.x). I deliberately did **not** commit regenerated snapshots since they're platform/version-sensitive — you'll likely want to regenerate them in your own CI environment. This also appears to be the same mismatch reported in #62 ("outputs were identical").

## Relation to #62

#62 targets the same issue but, as far as I can tell from installing and testing that branch against ggplot2 4.0.3, plain ggplot prints still record nothing: `S7::method(print, get("ggplot", ...)) <-` errors (that binding is the constructor function, not the S7 class — that would be `class_ggplot`), the `tryCatch` falls back to the original dead `"ggplot"` registration, and there's no guard for the `ggsave()` recursion. Details in a comment there. Credit to @seanthimons for getting to the S7 diagnosis first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)